### PR TITLE
Fix compilation issues

### DIFF
--- a/PloppableRCI/GUI/UIBuildingFilter.cs
+++ b/PloppableRCI/GUI/UIBuildingFilter.cs
@@ -1,6 +1,5 @@
 ﻿using UnityEngine;
 using ColossalFramework.UI;
-using System.Windows.Forms.VisualStyles;
 
 namespace PloppableRICO
 {
@@ -53,7 +52,7 @@ namespace PloppableRICO
                 {
                     categoryToggles[i].isChecked = false;
                 }
-                
+
                 // Select this toggle.
                 control.isChecked = true;
             }

--- a/PloppableRCI/Notifications/HarmonyNotification.cs
+++ b/PloppableRCI/Notifications/HarmonyNotification.cs
@@ -1,6 +1,4 @@
-﻿using System.Windows.Forms;
-
-namespace PloppableRICO
+﻿namespace PloppableRICO
 {
     /// <summary>
     /// A simple UI panel to show any mod conflict notifications.

--- a/PloppableRCI/RICOBuildingManager.cs
+++ b/PloppableRCI/RICOBuildingManager.cs
@@ -8,7 +8,7 @@ using UnityEngine;
 namespace PloppableRICO
 {
     /// <summary>
-    /// The data object that tracks what buildings are plopped, and which were grown. We can use this data to apply differnt AI logic to each. 
+    /// The data object that tracks what buildings are plopped, and which were grown. We can use this data to apply differnt AI logic to each.
     /// </summary>
 
     public class RICOBuildingManager : SerializableDataExtensionBase
@@ -40,18 +40,18 @@ namespace PloppableRICO
 
         public static void AddBuilding(BuildingInfo prefab, uint ID)
         {
-            //This is called from building tool. The data it sets is read by methods in the RICO AIs and BuildingTool detours. 
+            //This is called from building tool. The data it sets is read by methods in the RICO AIs and BuildingTool detours.
 
             Debug.Log("Add Building Called with ID = " + ID);
 
-            if (prefab.m_buildingAI is PloppableOffice || prefab.m_buildingAI is PloppableExtractor || prefab.m_buildingAI is PloppableResidential || prefab.m_buildingAI is PloppableCommercial || prefab.m_buildingAI is PloppableIndustrial)
+            if (prefab.m_buildingAI is PloppableOfficeAI || prefab.m_buildingAI is PloppableExtractorAI || prefab.m_buildingAI is PloppableResidentialAI || prefab.m_buildingAI is PloppableCommercialAI || prefab.m_buildingAI is PloppableIndustrialAI)
             {
 
                 RICOInstanceData data = RICOBuildingManager.RICOInstanceData[(int)ID];
                 if (data != null)
                 {
                     data.Name = prefab.name;
-                    data.plopped = true; //since this is called from building tool, it must be plopped. 
+                    data.plopped = true; //since this is called from building tool, it must be plopped.
                 }
 
             }
@@ -141,7 +141,7 @@ namespace PloppableRICO
 			Name = s.ReadSharedString();
 			//Depth = s.ReadInt32();
 			plopped = s.ReadBool();
-	
+
 		}
 
 		public void AfterDeserialize(DataSerializer s) {}


### PR DESCRIPTION
Due to references to classes like `PloppableOffice`, `PloppableExtractor`, ..., the freshly cloned project would not build. Maybe it was forgotten to be committed with 26ceca64f11ba4a3cdb1384503c9beab83bfc07a ?

Additionally, I removed two WinForms `using` directives because they're unused and not portable (let's show some ❤️ to Linux/Mac users).