### PR TITLE
Fix the "Low land value" and "Too few services" complaints

### DIFF
--- a/PloppableRCI/AI/AIUtils.cs
+++ b/PloppableRCI/AI/AIUtils.cs
@@ -21,8 +21,20 @@
             buildingData.m_flags &= ~Building.Flags.Abandoned;
             buildingData.m_flags &= ~Building.Flags.Demolishing;
 
-            // Make sure building isn't 'turned off' (otherwise this could be an issue with coverted parks, monuments, etc. that were previously turned off). 
+            // Make sure building isn't 'turned off' (otherwise this could be an issue with coverted parks, monuments, etc. that were previously turned off).
             buildingData.m_problems &= ~Notification.Problem.TurnedOff;
+
+            if (ModSettings.noValueRico)
+            {
+                // Disable the "Low land value" complaint
+                buildingData.m_problems &= ~Notification.Problem.LandValueLow;
+            }
+
+            if (ModSettings.noServicesRico)
+            {
+                // Disable the "Too few services" complaint
+                buildingData.m_problems &= ~Notification.Problem.TooFewServices;
+            }
         }
     }
 }


### PR DESCRIPTION
Despite the options being ticked in the settings panel, plopped buildings would still complain about the land value and/or services.

Resetting the respective m_problems flags before/after each simulation step time seems to work well to avoid this. What do you think?


_Here's an example of some Modern Japan buildings (RICO settings from the content creator) complaining:_
![Screenshot from 2020-07-25 17 56 01](https://user-images.githubusercontent.com/2804556/88461377-2ab94f00-cea3-11ea-83e3-28c5d2605a25.png)